### PR TITLE
bugfix : exponential notation for smaller numbers + custom ticker for…

### DIFF
--- a/src/components/Inline.js
+++ b/src/components/Inline.js
@@ -29,6 +29,10 @@ export const isFloat = n => {
 const locale = 'en-US';
 export const smartNumber = n => {
   if (isFloat(n)) {
+    if (n < 0.0001)
+      return colorDecimals(
+        n.toExponential(2)
+      );
     if (n < 0.001)
       return colorDecimals(
         n.toLocaleString(locale, {
@@ -56,7 +60,7 @@ export const smartNumber = n => {
         })
       );
   } else {
-    return colorDecimals(n.toLocaleString());
+    return colorDecimals(n.toLocaleString(locale));
   }
 };
 

--- a/src/components/charting/TradingViewWidget.jsx
+++ b/src/components/charting/TradingViewWidget.jsx
@@ -1,7 +1,7 @@
 import { createChart, ColorType, CrosshairMode } from 'lightweight-charts';
 import React, { useEffect, useRef } from 'react';
 import moment from 'moment';
-import { p2i, i2t, candleIntervalToMinutes } from '../../utils.js';
+import { p2i, i2t, candleIntervalToMinutes, customTickFormatter } from '../../utils.js';
 import { bigTickFormatter } from '../../utils.js';
 import { areaSeriesBottomOpacity, dexColors, hexToRgba } from '../../utils/colors.js';
 import { customAutoScalingProvider, defaultChartOptions, minZeroAutoScalingProvider } from '../../utils/chartUtils.js';
@@ -229,8 +229,12 @@ export const ChartComponent = props => {
       wickUpColor: '#26a69a',
       wickDownColor: '#ef5350',
       autoscaleInfoProvider: (original) => customAutoScalingProvider(original, priceMinGreaterThanZero, priceMaxGreaterThanZero),
-      localization: {
-        priceFormatter: bigTickFormatter,
+      // localization: {
+      //   priceFormatter: customTickFormatter,
+      // },
+      priceFormat: {
+        type: "custom",
+        formatter: customTickFormatter
       },
     });
     //candlestickSeries.setData(barData);

--- a/src/utils.js
+++ b/src/utils.js
@@ -159,3 +159,12 @@ export function lastStartedTick(tickInterval, currentTimestamp) {
 
 export const bigTickFormatter = t =>
   t < 1000000 ? (t / 1000).toFixed(1) + 'k' : (t / 1000000).toFixed(2) + 'm';
+
+export const customTickFormatter = t =>
+  t < 0.0001 ? t.toExponential(2) :
+  t < 1 ? t.toFixed(4) :
+  t < 10 ? t.toFixed(3) :
+  t < 100 ? t.toFixed(2) :
+  t < 1000 ? t.toFixed(1) :
+  t < 10000 ? t.toFixed(0) :
+  bigTickFormatter(t);


### PR DESCRIPTION
This PR contains the following fixes :
1. fixes the number formatting issues in very small numbers (eg DOGMI).
2. fixes International number formatting in multiple places
3. Introduces a custom ticker formatter for the candlestick charts , to handle different cases including 1.


![image](https://github.com/user-attachments/assets/a2041a19-562e-4d7e-a5d7-c8e3f05789f6)
