### PR TITLE
use high and low values additionally from the canister tick

### DIFF
--- a/src/components/charting/TradingViewWidget.jsx
+++ b/src/components/charting/TradingViewWidget.jsx
@@ -75,6 +75,8 @@ function convertRawDataToCandleData({
    * @property {number} ticp - Treasury ICP accumulation
    * @property {number} cs - Circulating supply difference
    * @property {...number} pN - Price of the Nth path
+   * @property {...number} plN - Lowest Price in candele of the Nth path
+   * @property {...number} phN - Highest Price in candle of the Nth path
    * @property {...number} vN - Volume of the Nth path converted to USD
    * @property {...number} lN - Depth of bid of the Nth path
    * @property {...number} laN - Depth of ask of the Nth path
@@ -138,11 +140,11 @@ function calculateSingleCandleDataFromPriceSubArray(priceSubArray, noOfPaths) {
       if (index == priceSubArray.length - 1) {
         close += d[`p${i}`];
       }
-      if (d[`p${i}`] < low) {
-        low = d[`p${i}`];
+      if (d[`pl${i}`] < low) {
+        low = d[`pl${i}`];
       }
-      if (d[`p${i}`] > high) {
-        high = d[`p${i}`];
+      if (d[`ph${i}`] > high) {
+        high = d[`ph${i}`];
       }
     }
   });

--- a/src/reducers/tokens.js
+++ b/src/reducers/tokens.js
@@ -579,6 +579,8 @@ export const selectSingleTokenInfo =
           r['cs'] = acc_cs;
           for (let pidx = 0; pidx < pathpair.length; pidx++) {
             r['p' + pidx] = pathpair[pidx][i].price;
+            r['pl' + pidx] = pathpair[pidx][i].low;
+            r['ph' + pidx] = pathpair[pidx][i].high;
             r['v' + pidx] = pathpair[pidx][i].volume24h
               ? pathpair[pidx][i].volume24h * usdprice
               : 0;

--- a/src/utils/dfs.js
+++ b/src/utils/dfs.js
@@ -87,6 +87,8 @@ export function calculatePathPrice(inc, getPrice, time, interval='t1h') {
   try {
     let path = inc.tokens;
     let pathPrice = 1; // Initialize to 1 as we'll be multiplying prices
+    let pathHigh = 1; // Initialize to 1 for multiplication
+    let pathLow = 1;  // Initialize to 1 for multiplication
     let volume24h = 0;
     let depthBid = 0;
     let depthAsk = 0;
@@ -95,9 +97,18 @@ export function calculatePathPrice(inc, getPrice, time, interval='t1h') {
 
       const p = x.p;
       let price = (p[2] + p[3]) / 2;
-      if (x.rev) price = 1 / price;
+      let high = p[0];
+      let low = p[1];
+
+      if (x.rev) {
+        price = 1 / price;
+        high = 1 / p[1]; // Reciprocal of low
+        low = 1 / p[0];  // Reciprocal of high
+      }
 
       pathPrice *= price;
+      pathHigh *= high;
+      pathLow *= low;
 
       if (i === 0) {
         volume24h = x.p[4];
@@ -110,13 +121,15 @@ export function calculatePathPrice(inc, getPrice, time, interval='t1h') {
     depthBid = depthBid * pathPrice;
     depthAsk = depthAsk * pathPrice;
 
-    return { price: pathPrice, volume24h, depthBid, depthAsk };
+    return { price: pathPrice, volume24h, depthBid, depthAsk, high: pathHigh, low: pathLow };
   } catch (e) {
     return {
       price: undefined,
       volume24h: undefined,
       depthBid: undefined,
       depthAsk: undefined,
+      high: undefined,
+      low: undefined,
     };
   }
 }


### PR DESCRIPTION
This PR adds the high and low value from the canister while calculating the candle graph data points.

# Evidence : 
## 5min ticks now have the bottom and top wicks :

<img width="1402" alt="image" src="https://github.com/user-attachments/assets/62659c5c-fec6-4c31-9670-894234247c9e">


## OBSERVATION

In the screenshot it can be seen that there are not many top wicks. This could be due to the fact that in the canister values for [high, low , lastbid, lastask ...] , the `high` value almost always is the same as `lastbid` and `lastask` as can be seen here :

![image](https://github.com/user-attachments/assets/f44239da-9c19-4a65-a6ed-80c5cca60719)
 